### PR TITLE
moving to filament upload component

### DIFF
--- a/database/migrations/0001_01_01_000007_create_authors_and_articles_table.php
+++ b/database/migrations/0001_01_01_000007_create_authors_and_articles_table.php
@@ -21,16 +21,10 @@ return new class extends Migration
             $table->text('bio')->nullable();
             $table->string('website')->nullable();
             $table->json('social_links')->nullable();
-            $table->unsignedInteger('featured_image_id')->nullable();
+            $table->string('photo')->nullable();
             $table->uuid('created_by');
             $table->uuid('updated_by');
             $table->timestamps();
-
-            $table->foreign('featured_image_id')
-                ->references('id')
-                ->on(app(config('wordsphere.curator.model'))
-                    ->getTable())
-                ->onDelete('set null');
 
             $table->foreign('created_by')
                 ->references('uuid')

--- a/src/Application/ContentManagement/Commands/CreateAuthorCommand.php
+++ b/src/Application/ContentManagement/Commands/CreateAuthorCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace WordSphere\Core\Application\ContentManagement\Commands;
 
-use WordSphere\Core\Domain\Shared\ValueObjects\Id;
 use WordSphere\Core\Domain\Shared\ValueObjects\Uuid;
 
 readonly class CreateAuthorCommand
@@ -16,6 +15,6 @@ readonly class CreateAuthorCommand
         public ?string $bio = null,
         public ?string $website = null,
         public ?array $socialLinks = [],
-        public ?Id $featuredImage = null,
+        public ?string $photo = null,
     ) {}
 }

--- a/src/Application/ContentManagement/Services/CreateAuthorService.php
+++ b/src/Application/ContentManagement/Services/CreateAuthorService.php
@@ -20,11 +20,12 @@ readonly class CreateAuthorService
         $author = new Author(
             id: $this->authorRepository->nextIdentity(),
             name: $command->name,
-            email: $command->email,
             createdBy: $command->createdBy,
             updatedBy: $command->createdBy,
+            email: $command->email,
             bio: $command->bio,
             website: $command->website,
+            photo: $command->photo,
             socialLinks: $command->socialLinks,
         );
 

--- a/src/Application/Factories/ContentManagement/AuthorFactory.php
+++ b/src/Application/Factories/ContentManagement/AuthorFactory.php
@@ -38,7 +38,7 @@ final class AuthorFactory extends Factory
             'id' => Uuid::generate(),
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
-            'featured_image_id' => null,
+            'photo' => null,
             'created_by' => Uuid::fromString($creator->uuid),
             'updated_by' => Uuid::fromString($creator->uuid),
         ];
@@ -49,7 +49,7 @@ final class AuthorFactory extends Factory
         return $this->afterMaking(function (EloquentAuthor $author): void {
             /** @var EloquentMedia $media */
             $media = MediaFactory::new()->create();
-            $author->featured_image_id = $media->id;
+            $author->photo = $media->path;
             $author->save();
         });
     }
@@ -58,7 +58,7 @@ final class AuthorFactory extends Factory
     {
         return $this->state(function (array $attributes) {
             return [
-                'featured_image_id' => null,
+                'photo' => null,
             ];
         });
     }
@@ -110,7 +110,7 @@ final class AuthorFactory extends Factory
             id: $authorData['id'],
             name: $authorData['name'],
             createdBy: $authorData['created_by'],
-            updatedBy: $authorData['created_by'],
+            updatedBy: $authorData['updated_by'],
             email: $authorData['email'],
             bio: array_key_exists('bio', $authorData) ? $authorData['bio'] : null,
             website: array_key_exists('bio', $authorData) ? $authorData['website'] : null,

--- a/src/Domain/ContentManagement/Entities/Author.php
+++ b/src/Domain/ContentManagement/Entities/Author.php
@@ -6,14 +6,11 @@ namespace WordSphere\Core\Domain\ContentManagement\Entities;
 
 use InvalidArgumentException;
 use WordSphere\Core\Domain\Shared\Concerns\HasAuditTrail;
-use WordSphere\Core\Domain\Shared\Concerns\HasFeaturedImage;
-use WordSphere\Core\Domain\Shared\ValueObjects\Id;
 use WordSphere\Core\Domain\Shared\ValueObjects\Uuid;
 
 class Author
 {
     use HasAuditTrail;
-    use HasFeaturedImage;
 
     private Uuid $id;
 
@@ -24,6 +21,8 @@ class Author
     private ?string $bio;
 
     private ?string $website;
+
+    private ?string $photo;
 
     private array $socialLinks;
 
@@ -44,7 +43,7 @@ class Author
         ?string $email = null,
         ?string $bio = null,
         ?string $website = null,
-        ?Id $featuredImage = null,
+        ?string $photo = null,
         ?array $socialLinks = [],
     ) {
         $this->id = $id;
@@ -52,14 +51,13 @@ class Author
         $this->email = $email;
         $this->bio = $bio;
         $this->website = $website;
-        $this->socialLinks = $socialLinks;
-        $this->updateFeaturedImage($featuredImage);
+        $this->photo = $photo;
         $this->socialLinks = $socialLinks;
 
         $this->createdBy = $createdBy;
         $this->updatedBy = $updatedBy;
 
-        $this->initializeHasAuditTrail($createdBy);
+        $this->initializeTimestamps();
     }
 
     public function getId(): Uuid
@@ -87,12 +85,17 @@ class Author
         return $this->website;
     }
 
+    public function getPhoto(): ?string
+    {
+        return $this->photo;
+    }
+
     public function getSocialLinks(): array
     {
         return $this->socialLinks;
     }
 
-    public function updateName(string $name, Uuid $updater): void
+    public function updateName(string $name): void
     {
 
         if (empty(trim($name))) {
@@ -100,10 +103,10 @@ class Author
         }
 
         $this->name = $name;
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
-    public function updateEmail(string $email, Uuid $updater): void
+    public function updateEmail(string $email): void
     {
 
         if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -111,45 +114,51 @@ class Author
         }
 
         $this->email = $email;
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
-    public function updateBio(?string $bio, Uuid $updater): void
+    public function updateBio(?string $bio): void
     {
         $this->bio = $bio;
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
-    public function updateWebsite(?string $website, Uuid $updater): void
+    public function updateWebsite(?string $website): void
     {
         if (! $website !== null && ! filter_var($website, FILTER_VALIDATE_URL)) {
             throw new InvalidArgumentException('Invalid website URL.');
         }
         $this->website = $website;
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
-    public function updateSocialLinks(array $socialLinks, Uuid $updater): void
+    public function updatePhoto(?string $photo): void
+    {
+        $this->photo = $photo;
+        $this->updateAuditTrail();
+    }
+
+    public function updateSocialLinks(array $socialLinks): void
     {
         foreach ($socialLinks as $platform => $username) {
             $this->validateSocialPlatform($platform);
         }
 
         $this->socialLinks = $socialLinks;
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
-    public function addSocialLink(string $platform, string $username, Uuid $updater): void
+    public function addSocialLink(string $platform, string $username): void
     {
         $this->validateSocialPlatform($platform);
         $this->socialLinks[$platform] = $username;
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
-    public function removeSocialLink(string $platform, Uuid $updater): void
+    public function removeSocialLink(string $platform): void
     {
         unset($this->socialLinks[$platform]);
-        $this->updateAuditTrail($updater);
+        $this->updateAuditTrail();
     }
 
     public function toArray(): array
@@ -160,8 +169,8 @@ class Author
             'email' => $this->getEmail(),
             'bio' => $this->getBio(),
             'website' => $this->getWebsite(),
+            'photo' => $this->getPhoto(),
             'socialLinks' => $this->getSocialLinks(),
-            'featuredImageId' => $this->getFeaturedImage()?->toInt(),
             'created_at' => $this->getCreatedAt()->format('Y-m-d H:i:s'),
             'updated_at' => $this->getUpdatedAt()->format('Y-m-d H:i:s'),
             'created_by' => $this->getCreatedBy()->toString(),

--- a/src/Domain/Shared/Concerns/HasAuditTrail.php
+++ b/src/Domain/Shared/Concerns/HasAuditTrail.php
@@ -12,16 +12,22 @@ trait HasAuditTrail
     use HasTimestamps;
     use HasUpdatedBy;
 
-    protected function initializeHasAuditTrail(Uuid $creator): void
+    protected function initializeHasAuditTrail(?Uuid $creator = null): void
     {
         $this->initializeTimestamps();
-        $this->createdBy = $creator;
-        $this->updatedBy = $creator;
+
+        if ($creator !== null) {
+            $this->createdBy = $creator;
+            $this->updatedBy = $creator;
+        }
+
     }
 
-    protected function updateAuditTrail(Uuid $updater): void
+    protected function updateAuditTrail(?Uuid $updater = null): void
     {
-        $this->updatedBy = $updater;
+        if ($updater !== null and property_exists($this, 'updatedBy')) {
+            $this->updatedBy = $updater;
+        }
         $this->updateTimestamps();
     }
 }

--- a/src/Infrastructure/ContentManagement/Adapters/AuthorAdapter.php
+++ b/src/Infrastructure/ContentManagement/Adapters/AuthorAdapter.php
@@ -3,7 +3,6 @@
 namespace WordSphere\Core\Infrastructure\ContentManagement\Adapters;
 
 use WordSphere\Core\Domain\ContentManagement\Entities\Author as DomainAuthor;
-use WordSphere\Core\Domain\Shared\ValueObjects\Id;
 use WordSphere\Core\Domain\Shared\ValueObjects\Uuid;
 use WordSphere\Core\Infrastructure\ContentManagement\Persistence\Models\EloquentAuthor;
 
@@ -29,7 +28,7 @@ class AuthorAdapter
             email: $eloquentAuthor->email,
             bio: $eloquentAuthor->bio,
             website: $eloquentAuthor->website,
-            featuredImage: $eloquentAuthor->featured_image_id ? Id::fromInt($eloquentAuthor->featured_image_id) : null,
+            photo: $eloquentAuthor->photo,
             socialLinks: $eloquentAuthor->social_links
         );
     }

--- a/src/Infrastructure/ContentManagement/Persistence/EloquentAuthorRepository.php
+++ b/src/Infrastructure/ContentManagement/Persistence/EloquentAuthorRepository.php
@@ -56,7 +56,7 @@ class EloquentAuthorRepository implements AuthorRepositoryInterface
         $eloquentAuthor->updated_by = $domainAuthor->getUpdatedBy()->toString();
         $eloquentAuthor->bio = $domainAuthor->getBio();
         $eloquentAuthor->website = $domainAuthor->getWebsite();
-        $eloquentAuthor->featured_image_id = $domainAuthor->getFeaturedImage()?->toInt();
+        $eloquentAuthor->photo = $domainAuthor->getPhoto();
         $eloquentAuthor->social_links = $domainAuthor->getSocialLinks();
         $eloquentAuthor->created_at = $domainAuthor->getCreatedAt();
         $eloquentAuthor->updated_at = $domainAuthor->getUpdatedAt();

--- a/src/Infrastructure/ContentManagement/Persistence/Models/EloquentAuthor.php
+++ b/src/Infrastructure/ContentManagement/Persistence/Models/EloquentAuthor.php
@@ -19,7 +19,7 @@ use WordSphere\Core\Infrastructure\Shared\Concerns\HasFeaturedImage;
  * @property string $bio
  * @property string $website
  * @property array $social_links
- * @property int $featured_image_id
+ * @property string $photo
  * @property string $created_by
  * @property Carbon|DateTimeImmutable $created_at
  * @property string $updated_by

--- a/src/Infrastructure/ContentManagement/Persistence/Models/EloquentMedia.php
+++ b/src/Infrastructure/ContentManagement/Persistence/Models/EloquentMedia.php
@@ -15,6 +15,7 @@ use WordSphere\Core\Application\Factories\ContentManagement\MediaFactory;
  * @property int $id
  * @property string $uuid
  * @property-read mixed $full_path
+ * @property-read mixed $path
  * @property-read mixed $large_url
  * @property-read mixed $medium_url
  * @property-read mixed $pretty_name

--- a/src/Interfaces/Filament/Resources/AuthorResource.php
+++ b/src/Interfaces/Filament/Resources/AuthorResource.php
@@ -2,11 +2,11 @@
 
 namespace WordSphere\Core\Interfaces\Filament\Resources;
 
-use Awcodes\Curator\Components\Forms\CuratorPicker;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use WordSphere\Core\Infrastructure\ContentManagement\Persistence\Models\EloquentAuthor;
@@ -31,13 +31,16 @@ class AuthorResource extends Resource
                         ->tabs([
                             Forms\Components\Tabs\Tab::make('General')
                                 ->schema([
-                                    CuratorPicker::make('featured_image_id')
-                                        ->label(__('Photo'))
-                                        ->buttonLabel(__('Select Photo'))
-                                        ->listDisplay(false),
+                                    Forms\Components\FileUpload::make('photo')
+                                        ->image()
+                                        ->avatar()
+                                        ->directory('author-photos')
+                                        ->maxSize(1024) // 1MB limit
+                                        ->disk('public'),
                                     Forms\Components\TextInput::make('name')
                                         ->label(__('Name'))
-                                        ->required(),
+                                        ->required()
+                                        ->columnSpan(2),
                                     Forms\Components\RichEditor::make('bio')
                                         ->label(__('Bio'))
                                         ->columnSpan(2),
@@ -76,16 +79,6 @@ class AuthorResource extends Resource
                                 ])
                                 ->columns(2),
                         ]),
-                    Forms\Components\Group::make()
-                        ->schema(
-                            components: [
-                                Forms\Components\Section::make()
-                                    ->schema([
-
-                                    ]),
-                            ]
-                        )
-                        ->grow(false),
                 ]
             )->columns(1);
     }
@@ -94,7 +87,13 @@ class AuthorResource extends Resource
     {
         return $table
             ->columns([
+                ImageColumn::make('photo')
+                    ->label(__('Photo'))
+                    ->circular(),
                 TextColumn::make('name')
+                    ->extraAttributes([
+                        'class' => 'font-semibold',
+                    ])
                     ->searchable()
                     ->label(__('Name')),
                 TextColumn::make('website')

--- a/src/Interfaces/Filament/Resources/AuthorResource/Pages/CreateAuthor.php
+++ b/src/Interfaces/Filament/Resources/AuthorResource/Pages/CreateAuthor.php
@@ -7,7 +7,6 @@ use Illuminate\Auth\AuthManager;
 use WordSphere\Core\Application\ContentManagement\Commands\CreateAuthorCommand;
 use WordSphere\Core\Application\ContentManagement\Services\CreateAuthorService;
 use WordSphere\Core\Domain\ContentManagement\Repositories\AuthorRepositoryInterface;
-use WordSphere\Core\Domain\Shared\ValueObjects\Id;
 use WordSphere\Core\Domain\Shared\ValueObjects\Uuid;
 use WordSphere\Core\Infrastructure\ContentManagement\Adapters\AuthorAdapter;
 use WordSphere\Core\Infrastructure\ContentManagement\Persistence\Models\EloquentAuthor;
@@ -47,7 +46,7 @@ class CreateAuthor extends CreateRecord
             bio: $this->getData('bio', $data),
             website: $this->getData('website', $data),
             socialLinks: $this->getData('social_links', $data),
-            featuredImage: $this->getData('featuredImage', $data) ? Id::fromInt($this->getData('featuredImage', $data)) : null,
+            photo: $this->getData('photo', $data),
         );
 
         $authorId = $this->createAuthorService->execute($command);

--- a/tests/Unit/Domain/ContentManagement/Entities/AuthorTest.php
+++ b/tests/Unit/Domain/ContentManagement/Entities/AuthorTest.php
@@ -2,13 +2,11 @@
 
 use WordSphere\Core\Application\Factories\ContentManagement\AuthorFactory;
 use WordSphere\Core\Domain\ContentManagement\Entities\Author as DomainAuthor;
-use WordSphere\Core\Domain\Shared\ValueObjects\Id;
 use WordSphere\Core\Domain\Shared\ValueObjects\Uuid;
 
 test('can create an author with al properties', function (): void {
     $authorId = Uuid::generate();
     $createdBy = Uuid::generate();
-    $featuredImage = Id::fromInt(0);
     $author = new DomainAuthor(
         id: $authorId,
         name: 'Francisco B.',
@@ -17,7 +15,7 @@ test('can create an author with al properties', function (): void {
         email: 'francisco.b@example.com',
         bio: 'A passionate laravel developer',
         website: 'https://pinkary.com',
-        featuredImage: $featuredImage,
+        photo: 'profile-photo.jpg',
         socialLinks: ['twitter' => 'francisco.b', 'facebook' => 'francisco.b']
     );
 
@@ -29,7 +27,7 @@ test('can create an author with al properties', function (): void {
         ->and($author->getBio())->toBe('A passionate laravel developer')
         ->and($author->getWebsite())->toBe('https://pinkary.com')
         ->and($author->getSocialLinks())->toBe(['twitter' => 'francisco.b', 'facebook' => 'francisco.b'])
-        ->and($author->getFeaturedImage())->toBe($featuredImage)
+        ->and($author->getPhoto())->toBe('profile-photo.jpg')
         ->and($author->getCreatedBy())->toBe($createdBy)
         ->and($author->getUpdatedBy())->toBe($createdBy)
         ->and($author->getCreatedAt())->toBeInstanceOf(DateTimeImmutable::class)
@@ -40,10 +38,12 @@ test('can create an author with al properties', function (): void {
 test('can update author and track changes', function (): void {
     $updatedBy = Uuid::generate();
     $author = AuthorFactory::new()
-        ->makeForDomain();
+        ->makeForDomain([
+            'updated_by' => $updatedBy
+        ]);
 
-    $author->updateName('John Doe', $updatedBy);
-    $author->updateEmail('john.doe@example.com', $updatedBy);
+    $author->updateName('John Doe');
+    $author->updateEmail('john.doe@example.com');
 
     expect($author->getName())
         ->toBe('John Doe')
@@ -81,7 +81,7 @@ test('can update author bio', function (): void {
         email: 'francisco.b@example.com',
     );
 
-    $author->updateBio('An experience journalist', $createdBy);
+    $author->updateBio('An experience journalist');
 
     expect($author->getBio())
         ->toBe('An experience journalist');
@@ -92,8 +92,7 @@ test('can update social links', function (): void {
         ->makeForDomain();
 
     $author->updateSocialLinks(
-        ['twitter' => 'francisco.b', 'facebook' => 'francisco.b'],
-        $author->getCreatedBy()
+        ['twitter' => 'francisco.b', 'facebook' => 'francisco.b']
     );
 
     expect($author->getSocialLinks())
@@ -107,8 +106,8 @@ test('can add a single social link', function (): void {
     $author = AuthorFactory::new()
         ->makeForDomain();
 
-    $author->addSocialLink('twitter', 'francisco.b', $author->getCreatedBy());
-    $author->addSocialLink('facebook', 'francisco.b', $author->getCreatedBy());
+    $author->addSocialLink('twitter', 'francisco.b');
+    $author->addSocialLink('facebook', 'francisco.b');
 
     expect($author->getSocialLinks())
         ->toBe(['twitter' => 'francisco.b', 'facebook' => 'francisco.b']);
@@ -119,8 +118,8 @@ test('can remove a social link', function (): void {
     $author = AuthorFactory::new()
         ->makeForDomain();
 
-    $author->addSocialLink('twitter', 'francisco.b', $author->getCreatedBy());
-    $author->removeSocialLink('twitter', $author->getCreatedBy());
+    $author->addSocialLink('twitter', 'francisco.b');
+    $author->removeSocialLink('twitter');
 
     expect($author->getSocialLinks())->toBe([]);
 });

--- a/workbench/config/filesystems.php
+++ b/workbench/config/filesystems.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Filesystem Disk
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default filesystem disk that should be used
+    | by the framework. The "local" disk, as well as a variety of cloud
+    | based disks are available to your application for file storage.
+    |
+    */
+
+    'default' => env('FILESYSTEM_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filesystem Disks
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure as many filesystem disks as necessary, and you
+    | may even configure multiple disks for the same driver. Examples for
+    | most supported storage drivers are configured here for reference.
+    |
+    | Supported Drivers: "local", "ftp", "sftp", "s3"
+    |
+    */
+
+    'disks' => [
+
+        'local' => [
+            'driver' => 'local',
+            'root' => storage_path('app'),
+            'throw' => false,
+        ],
+
+        'public' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public'),
+            'url' => env('APP_URL').'/storage',
+            'visibility' => 'public',
+            'throw' => false,
+        ],
+
+        's3' => [
+            'driver' => 's3',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
+            'bucket' => env('AWS_BUCKET'),
+            'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Symbolic Links
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the symbolic links that will be created when the
+    | `storage:link` Artisan command is executed. The array keys should be
+    | the locations of the links and the values should be their targets.
+    |
+    */
+
+    'links' => [
+        public_path('storage') => storage_path('app/public'),
+    ],
+
+];


### PR DESCRIPTION
This pull request includes several changes to replace the `featured_image_id` field with a `photo` field for the `Author` entity. The changes span across multiple files in the application, including migrations, commands, services, factories, entities, adapters, and resources.

### Key Changes:

#### Database and Migrations:
* Replaced `featured_image_id` with `photo` in the `authors` table schema. (`database/migrations/0001_01_01_000007_create_authors_and_articles_table.php`)

#### Application Layer:
* Updated `CreateAuthorCommand` to use `photo` instead of `featuredImage`. (`src/Application/ContentManagement/Commands/CreateAuthorCommand.php`) [[1]](diffhunk://#diff-cc0b3403b9bd1f162d0c637f093432375965c72a428c99646c49f5b601e34a4dL7) [[2]](diffhunk://#diff-cc0b3403b9bd1f162d0c637f093432375965c72a428c99646c49f5b601e34a4dL19-R18)
* Adjusted `CreateAuthorService` to handle the `photo` field. (`src/Application/ContentManagement/Services/CreateAuthorService.php`)

#### Domain Layer:
* Modified `Author` entity to include `photo` and removed `HasFeaturedImage` trait. (`src/Domain/ContentManagement/Entities/Author.php`) [[1]](diffhunk://#diff-f440cf22588a1e70c90da00443c7ea35fc290522e87ec97bbf002c90428c746fL9-L16) [[2]](diffhunk://#diff-f440cf22588a1e70c90da00443c7ea35fc290522e87ec97bbf002c90428c746fR25-R26) [[3]](diffhunk://#diff-f440cf22588a1e70c90da00443c7ea35fc290522e87ec97bbf002c90428c746fL47-R60) [[4]](diffhunk://#diff-f440cf22588a1e70c90da00443c7ea35fc290522e87ec97bbf002c90428c746fR88-R161) [[5]](diffhunk://#diff-f440cf22588a1e70c90da00443c7ea35fc290522e87ec97bbf002c90428c746fR172-L164)
* Enhanced `HasAuditTrail` trait to make `creator` and `updater` parameters optional. (`src/Domain/Shared/Concerns/HasAuditTrail.php`)

#### Infrastructure Layer:
* Updated `AuthorAdapter` to map `photo` field. (`src/Infrastructure/ContentManagement/Adapters/AuthorAdapter.php`) [[1]](diffhunk://#diff-2fbae2a945e1e3d0cf0b4c5ef9def0445da17eba990a58b0b8cb1795d12b6ec1L6) [[2]](diffhunk://#diff-2fbae2a945e1e3d0cf0b4c5ef9def0445da17eba990a58b0b8cb1795d12b6ec1L32-R31)
* Modified `EloquentAuthor` model to include `photo` property. (`src/Infrastructure/ContentManagement/Persistence/Models/EloquentAuthor.php`)

#### Interface Layer:
* Updated `AuthorResource` to use `photo` field in forms and tables. (`src/Interfaces/Filament/Resources/AuthorResource.php`) [[1]](diffhunk://#diff-c8637ce0913a8f8022addb93a43560018a1e2cef597c5918065d46d12f9aaa78L5-R9) [[2]](diffhunk://#diff-c8637ce0913a8f8022addb93a43560018a1e2cef597c5918065d46d12f9aaa78L34-R43) [[3]](diffhunk://#diff-c8637ce0913a8f8022addb93a43560018a1e2cef597c5918065d46d12f9aaa78R90-R96)
* Adjusted `CreateAuthor` page to handle `photo` field. (`src/Interfaces/Filament/Resources/AuthorResource/Pages/CreateAuthor.php`) [[1]](diffhunk://#diff-879c00efeb4bebd9e3478e1cce06da8533feebd5f339b0dd9f8d7c482bf2b6cfL10) [[2]](diffhunk://#diff-879c00efeb4bebd9e3478e1cce06da8533feebd5f339b0dd9f8d7c482bf2b6cfL50-R49)

#### Testing:
* Updated unit tests to reflect changes from `featured_image_id` to `photo`. (`tests/Unit/Domain/ContentManagement/Entities/AuthorTest.php`) [[1]](diffhunk://#diff-8b701a17219aa38eb69a05f5d87b110e0f84dde1134f5dc2a893aaebb59917eeL5-L11) [[2]](diffhunk://#diff-8b701a17219aa38eb69a05f5d87b110e0f84dde1134f5dc2a893aaebb59917eeL20-R18)