### PR TITLE
added ContentType value objects and the starting to implement the Con…

### DIFF
--- a/src/Domain/ContentManagement/ContentTypeRegistry.php
+++ b/src/Domain/ContentManagement/ContentTypeRegistry.php
@@ -8,7 +8,6 @@ use WordSphere\Core\Domain\ContentManagement\ValueObjects\ContentType;
 
 class ContentTypeRegistry
 {
-
     private array $contentTypes = [];
 
     public function register(ContentType $contentType): void
@@ -25,5 +24,4 @@ class ContentTypeRegistry
     {
         return $this->contentTypes;
     }
-
 }

--- a/src/Domain/ContentManagement/ContentTypeRegistry.php
+++ b/src/Domain/ContentManagement/ContentTypeRegistry.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordSphere\Core\Domain\ContentManagement;
+
+use WordSphere\Core\Domain\ContentManagement\ValueObjects\ContentType;
+
+class ContentTypeRegistry
+{
+
+    private array $contentTypes = [];
+
+    public function register(ContentType $contentType): void
+    {
+        $this->contentTypes[$contentType->key] = $contentType;
+    }
+
+    public function get(string $key): ?ContentType
+    {
+        return $this->contentTypes[$key] ?? null;
+    }
+
+    public function all(): array
+    {
+        return $this->contentTypes;
+    }
+
+}

--- a/src/Domain/ContentManagement/ValueObjects/ContentType.php
+++ b/src/Domain/ContentManagement/ValueObjects/ContentType.php
@@ -6,13 +6,11 @@ namespace WordSphere\Core\Domain\ContentManagement\ValueObjects;
 
 class ContentType
 {
-
-    public function __construct (
+    public function __construct(
         public readonly string $key,
         public readonly string $singularName,
         public readonly string $pluralName,
         public readonly string $description,
         public readonly string $icon
-    ) { }
-
+    ) {}
 }

--- a/src/Domain/ContentManagement/ValueObjects/ContentType.php
+++ b/src/Domain/ContentManagement/ValueObjects/ContentType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WordSphere\Core\Domain\ContentManagement\ValueObjects;
+
+class ContentType
+{
+
+    public function __construct (
+        public readonly string $key,
+        public readonly string $singularName,
+        public readonly string $pluralName,
+        public readonly string $description,
+        public readonly string $icon
+    ) { }
+
+}

--- a/tests/Feature/ContentManagement/Articles/CreateArticleTest.php
+++ b/tests/Feature/ContentManagement/Articles/CreateArticleTest.php
@@ -3,7 +3,6 @@
 use WordSphere\Core\Application\ContentManagement\Commands\CreateArticleCommand;
 use WordSphere\Core\Application\ContentManagement\Services\CreateArticleService;
 use WordSphere\Core\Domain\ContentManagement\Repositories\ArticleRepositoryInterface;
-use WordSphere\Core\Domain\ContentManagement\ValueObjects\ArticleUuid;
 use WordSphere\Core\Domain\Shared\ValueObjects\Uuid;
 use WordSphere\Core\Infrastructure\ContentManagement\Persistence\EloquentArticleRepository;
 use WordSphere\Core\Infrastructure\Identity\Persistence\EloquentUser;

--- a/tests/Feature/ContentManagement/Articles/UpdateArticleTest.php
+++ b/tests/Feature/ContentManagement/Articles/UpdateArticleTest.php
@@ -73,6 +73,8 @@ test('can update an article', function (): void {
 
 test('updating article with existing slug appends number to slug', function (): void {
 
+    $this->travel(5)->days();
+
     ArticleFactory::new()
         ->create(
             attributes: [
@@ -103,6 +105,8 @@ test('updating article with existing slug appends number to slug', function (): 
         ->toStartWith('updated-slug-')
         ->and($updatedArticle->getSlug()->toString())->not
         ->toBe('updated-slug');
+
+    $this->travelBack();
 
 });
 


### PR DESCRIPTION
This pull request introduces a `ContentTypeRegistry` class to manage content types and a `ContentType` value object to represent individual content types. Additionally, there are some adjustments in the test files to improve test accuracy and remove unused imports.

### Content Management Enhancements:

* [`src/Domain/ContentManagement/ContentTypeRegistry.php`](diffhunk://#diff-ecc6b5f369ecceaeb23252e0d1df387d7c71aa324a716a15989e0fb811f684ebR1-R27): Introduced the `ContentTypeRegistry` class to register, retrieve, and list content types.
* [`src/Domain/ContentManagement/ValueObjects/ContentType.php`](diffhunk://#diff-bcc0d74fc02f680c2d385bc57c90faa91ad824fe273a6e9e58d887485b34c4f9R1-R16): Added the `ContentType` value object to encapsulate properties like `key`, `singularName`, `pluralName`, `description`, and `icon`.

### Testing Improvements:

* [`tests/Feature/ContentManagement/Articles/UpdateArticleTest.php`](diffhunk://#diff-7baf9a6a948c25eec3ccb1a54aedf406cb01f58d0c0808e0c6fc27aa0f6ba71eR76-R77): Added time travel methods to ensure the accuracy of tests related to article slugs. [[1]](diffhunk://#diff-7baf9a6a948c25eec3ccb1a54aedf406cb01f58d0c0808e0c6fc27aa0f6ba71eR76-R77) [[2]](diffhunk://#diff-7baf9a6a948c25eec3ccb1a54aedf406cb01f58d0c0808e0c6fc27aa0f6ba71eR109-R110)

### Code Cleanup:

* [`tests/Feature/ContentManagement/Articles/CreateArticleTest.php`](diffhunk://#diff-e4437cf42f74bbb846d9cff61986b803388896514bc6c60beca4d86f3ebeac92L6): Removed the unused import for `ArticleUuid`.This pull request introduces a new content type management system by adding a `ContentTypeRegistry` class and a `ContentType` value object. Additionally, it includes some minor cleanup in the test files. Below are the most important changes:

### Content Management System:

* [`src/Domain/ContentManagement/ContentTypeRegistry.php`](diffhunk://#diff-ecc6b5f369ecceaeb23252e0d1df387d7c71aa324a716a15989e0fb811f684ebR1-R29): Added a `ContentTypeRegistry` class to manage content types, including methods to register, retrieve, and list all content types.
* [`src/Domain/ContentManagement/ValueObjects/ContentType.php`](diffhunk://#diff-bcc0d74fc02f680c2d385bc57c90faa91ad824fe273a6e9e58d887485b34c4f9R1-R18): Introduced a `ContentType` value object to represent individual content types with properties like `key`, `singularName`, `pluralName`, `description`, and `icon`.

### Test Cleanup:

* [`tests/Feature/ContentManagement/Articles/CreateArticleTest.php`](diffhunk://#diff-e4437cf42f74bbb846d9cff61986b803388896514bc6c60beca4d86f3ebeac92L6): Removed an unused import for `ArticleUuid` to clean up the test file.…tentTypeRegistry